### PR TITLE
[Utils] Added function to merge co-linear line segments

### DIFF
--- a/include/geometry_common/Utils.h
+++ b/include/geometry_common/Utils.h
@@ -509,6 +509,8 @@ class Utils
          * @brief Merge co-linear line segments
          *
          * @param line_segments input line segments
+         * @param distance_threshold threshold for distance between two line
+         * segments
          * @param angle_threshold threshold for relative angle between two line
          * segments
          * @param perp_dist_threshold threshold for perpendicular distance
@@ -516,6 +518,7 @@ class Utils
          */
         static void mergeCoLinearLines(
                 std::vector<LineSegment2D>& line_segments,
+                float distance_threshold = 0.2f,
                 float angle_threshold = 0.2f,
                 float perp_dist_threshold = 0.1f);
 

--- a/include/geometry_common/Utils.h
+++ b/include/geometry_common/Utils.h
@@ -490,8 +490,8 @@ class Utils
          */
         static void mergeCloseLines(
                 std::vector<LineSegment2D>& line_segments,
-                float distance_threshold = 0.2,
-                float angle_threshold = 0.2);
+                float distance_threshold = 0.2f,
+                float angle_threshold = 0.2f);
 
         /**
          * @brief 
@@ -502,8 +502,19 @@ class Utils
          */
         static void mergeCloseLinesBF(
                 std::vector<LineSegment2D>& line_segments,
-                float distance_threshold = 0.2,
-                float angle_threshold = 0.2);
+                float distance_threshold = 0.2f,
+                float angle_threshold = 0.2f);
+
+        /**
+         * @brief Merge co-linear line segments
+         *
+         * @param line_segments input line segments
+         * @param perp_dist_threshold threshold for perpendicular distance
+         * between two line segments
+         */
+        static void mergeCoLinearLines(
+                std::vector<LineSegment2D>& line_segments,
+                float perp_dist_threshold = 0.1f);
 
         /**
          * @brief 

--- a/include/geometry_common/Utils.h
+++ b/include/geometry_common/Utils.h
@@ -509,11 +509,14 @@ class Utils
          * @brief Merge co-linear line segments
          *
          * @param line_segments input line segments
+         * @param angle_threshold threshold for relative angle between two line
+         * segments
          * @param perp_dist_threshold threshold for perpendicular distance
          * between two line segments
          */
         static void mergeCoLinearLines(
                 std::vector<LineSegment2D>& line_segments,
+                float angle_threshold = 0.2f,
                 float perp_dist_threshold = 0.1f);
 
         /**

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1012,6 +1012,7 @@ void Utils::mergeCloseLinesBF(
 
 void Utils::mergeCoLinearLines(
         std::vector<LineSegment2D>& line_segments,
+        float angle_threshold,
         float perp_dist_threshold)
 {
     if (line_segments.size() < 2)
@@ -1026,17 +1027,20 @@ void Utils::mergeCoLinearLines(
         size_t i = 0;
         while ( i+skip_index < line_segments.size() )
         {
+            const float angular_dist = Utils::calcShortestAngle(
+                    line_segments[i].angle(), line_segments[i+skip_index].angle());
             const Point2D start_proj_pt = Utils::calcProjectedPointOnLine(
                     line_segments[i].start, line_segments[i].end,
                     line_segments[i+skip_index].start, false);
-            float start_perp_dist = start_proj_pt.distTo(
+            const float start_perp_dist = start_proj_pt.distTo(
                     line_segments[i+skip_index].start);
             const Point2D end_proj_pt = Utils::calcProjectedPointOnLine(
                     line_segments[i].start, line_segments[i].end,
                     line_segments[i+skip_index].end, false);
-            float end_perp_dist = end_proj_pt.distTo(
+            const float end_perp_dist = end_proj_pt.distTo(
                     line_segments[i+skip_index].end);
-            if ( start_perp_dist < perp_dist_threshold &&
+            if ( std::fabs(angular_dist) < angle_threshold &&
+                 start_perp_dist < perp_dist_threshold &&
                  end_perp_dist < perp_dist_threshold )
             {
                 line_segments[i].end = line_segments[i+skip_index].end;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1012,6 +1012,7 @@ void Utils::mergeCloseLinesBF(
 
 void Utils::mergeCoLinearLines(
         std::vector<LineSegment2D>& line_segments,
+        float distance_threshold,
         float angle_threshold,
         float perp_dist_threshold)
 {
@@ -1027,6 +1028,8 @@ void Utils::mergeCoLinearLines(
         size_t i = 0;
         while ( i+skip_index < line_segments.size() )
         {
+            const float linear_dist = line_segments[i].end.distTo(
+                    line_segments[i+skip_index].start);
             const float angular_dist = Utils::calcShortestAngle(
                     line_segments[i].angle(), line_segments[i+skip_index].angle());
             const Point2D start_proj_pt = Utils::calcProjectedPointOnLine(
@@ -1039,7 +1042,8 @@ void Utils::mergeCoLinearLines(
                     line_segments[i+skip_index].end, false);
             const float end_perp_dist = end_proj_pt.distTo(
                     line_segments[i+skip_index].end);
-            if ( std::fabs(angular_dist) < angle_threshold &&
+            if ( linear_dist < distance_threshold &&
+                 std::fabs(angular_dist) < angle_threshold &&
                  start_perp_dist < perp_dist_threshold &&
                  end_perp_dist < perp_dist_threshold )
             {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1010,6 +1010,45 @@ void Utils::mergeCloseLinesBF(
     }
 }
 
+void Utils::mergeCoLinearLines(
+        std::vector<LineSegment2D>& line_segments,
+        float perp_dist_threshold)
+{
+    if (line_segments.size() < 2)
+    {
+        return;
+    }
+
+    size_t skip_index = 1;
+
+    while ( skip_index < line_segments.size() )
+    {
+        size_t i = 0;
+        while ( i+skip_index < line_segments.size() )
+        {
+            const Point2D start_proj_pt = Utils::calcProjectedPointOnLine(
+                    line_segments[i].start, line_segments[i].end,
+                    line_segments[i+skip_index].start, false);
+            float start_perp_dist = start_proj_pt.distTo(
+                    line_segments[i+skip_index].start);
+            const Point2D end_proj_pt = Utils::calcProjectedPointOnLine(
+                    line_segments[i].start, line_segments[i].end,
+                    line_segments[i+skip_index].end, false);
+            float end_perp_dist = end_proj_pt.distTo(
+                    line_segments[i+skip_index].end);
+            if ( start_perp_dist < perp_dist_threshold &&
+                 end_perp_dist < perp_dist_threshold )
+            {
+                line_segments[i].end = line_segments[i+skip_index].end;
+                line_segments.erase(line_segments.begin() + i + skip_index);
+                continue;
+            }
+            i++;
+        }
+        skip_index ++;
+    }
+}
+
 std::vector<LineSegment2D> Utils::fitLineSegments(
         const PointCloud2D& pts,
         float regression_error_threshold,


### PR DESCRIPTION
When line segments are co-linear but their end points are far apart, the current `mergeCloseLinesBF` does not work. For this case, a new function is added which merges line segments when perpendicular distance between two line segments is smaller than a threshold.

cc @blumenthal @wnowak  